### PR TITLE
Update links to Sienna website Plus minor fixes

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,7 @@ CurrentModule = SiennaTemplate
 
 `SiennaTemplate.jl` is part of the National Renewable Energy Laboratory's
 [Sienna ecosystem](https://nrel-sienna.github.io/Sienna/), an open source framework for
-scheduling problems and dynamic simulations for power systems. The Sienna ecosystem can be
+power system modeling, simulation, and optimization. The Sienna ecosystem can be
 [found on github](https://github.com/NREL-Sienna/Sienna). It contains three applications:
 
   - [Sienna\Data](https://nrel-sienna.github.io/Sienna/pages/applications/sienna_data.html) enables

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,18 +8,18 @@ CurrentModule = SiennaTemplate
 
 `SiennaTemplate.jl` is a [`Julia`](http://www.julialang.org) package that provides blah blah
 
-## About
+## About Sienna
 
-`SiennaTemplate` is part of the National Renewable Energy Laboratory's
-[Sienna ecosystem](https://www.nrel.gov/analysis/sienna.html), an open source framework for
+`SiennaTemplate.jl` is part of the National Renewable Energy Laboratory's
+[Sienna ecosystem](https://nrel-sienna.github.io/Sienna/), an open source framework for
 scheduling problems and dynamic simulations for power systems. The Sienna ecosystem can be
 [found on github](https://github.com/NREL-Sienna/Sienna). It contains three applications:
 
-  - [Sienna\Data](https://github.com/NREL-Sienna/Sienna?tab=readme-ov-file#siennadata) enables
+  - [Sienna\Data](https://nrel-sienna.github.io/Sienna/pages/applications/sienna_data.html) enables
     efficient data input, analysis, and transformation
-  - [Sienna\Ops](https://github.com/NREL-Sienna/Sienna?tab=readme-ov-file#siennaops) enables
+  - [Sienna\Ops](https://nrel-sienna.github.io/Sienna/pages/applications/sienna_ops.html) enables
     enables system scheduling simulations by formulating and solving optimization problems
-  - [Sienna\Dyn](https://github.com/NREL-Sienna/Sienna?tab=readme-ov-file#siennadyn) enables
+  - [Sienna\Dyn](https://nrel-sienna.github.io/Sienna/pages/applications/sienna_dyn.html) enables
     system transient analysis including small signal stability and full system dynamic
     simulations
 

--- a/docs/src/reference/developer_guidelines.md
+++ b/docs/src/reference/developer_guidelines.md
@@ -1,11 +1,12 @@
 # Developer Guidelines
 
-In order to contribute to `PowerSystems.jl` repository please read the following sections of
-[`InfrastructureSystems.jl`](https://github.com/NREL-Sienna/InfrastructureSystems.jl)
+In order to contribute to `SiennaTemplate.jl` repository please read the following sections of
+[`InfrastructureSystems.jl`](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/) and [`SiennaTemplate.jl`](https://github.com/NREL-Sienna/SiennaTemplate.jl)
 documentation in detail:
 
  1. [Style Guide](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/style/)
- 2. [Contributing Guidelines](https://github.com/NREL-Sienna/SiennaTemplate.jl/blob/main/CONTRIBUTING.md)
+ 2. [Documentation Best Practices](https://nrel-sienna.github.io/InfrastructureSystems.jl/stable/docs_best_practices/explanation/)
+ 3. [Contributing Guidelines](https://github.com/NREL-Sienna/SiennaTemplate.jl/blob/main/CONTRIBUTING.md)
 
 Pull requests are always welcome to fix bugs or add additional modeling capabilities.
 


### PR DESCRIPTION
This updates our About section to link to the Sienna website. Also adds the docs best practices to contributor guidelines, and fixes a name and a link in that file.

